### PR TITLE
update post_component to work with phoenix 1.6

### DIFF
--- a/lib/chirp_web/live/post_live/post_component.ex
+++ b/lib/chirp_web/live/post_live/post_component.ex
@@ -2,13 +2,13 @@ defmodule ChirpWeb.PostLive.PostComponent do
   use ChirpWeb, :live_component
 
   def render(assigns) do
-    ~L"""
+    ~H"""
       <div class="container">
         <%= @post.body %> |
-        <a href="#" phx-click="like" phx-target="<%= @myself %>">
+        <a href="#" phx-click="like" phx-target={@myself}>
         Like (<%= @post.likes_count %>)
         </a> |
-        <a href="#" phx-click="repost" phx-target="<%= @myself %>">
+        <a href="#" phx-click="repost" phx-target={@myself}>
         Repost (<%= @post.reposts_count %>)
         </a> |
         <span><%= live_patch "Edit", to: Routes.post_index_path(@socket, :edit, @post) %></span> |


### PR DESCRIPTION
Hi,
thank you for publishing this repository. It really helped me when the tutorial went over my head and I could not write down everything that was dictated.

Since the tutorial was released, Phoenix 1.6 came around and broke some features that were shown in the video.
One issue that came up was moving from `leex` to `heex` templates, as described in some [upgrade instructions](https://gist.github.com/chrismccord/2ab350f154235ad4a4d0f4de6decba7b#rename-your-htmleex-and-htmlleex-templates-to-htmlheex-optional).

With Phoenix 1.6, these changes are required to make the component work, otherwise an error page will pop up.